### PR TITLE
fix #9 : `construct` for null samplevector/file

### DIFF
--- a/R/sincera.R
+++ b/R/sincera.R
@@ -96,7 +96,7 @@ construct <- function(exprmatrix=NULL, exprfile=NULL,
 	  if (!is.null(samplefile)) {
 		  rsampleinfo <- as.character(read.table(file=samplefile, sep="\t", header=F, check.names=FALSE)$V1)
 	  } else {
-		  rsampleinfo <- rep("sample1", dim(rexpr)[2])
+		  rsampleinfo <- rep("sample1", dim(rexprs)[2])
 	  }
   }
 


### PR DESCRIPTION
When construct was called without a samplevector or samplefile argument the
original code referred to `rexpr`, but no variable `rexpr` was in scope.
This should have referred to `rexprs`, a variable that was in scope.

I fixed the `rexpr` typo to `rexprs`